### PR TITLE
fix: update MCP search to use query_points() API

### DIFF
--- a/packages/qdrant-loader-mcp-server/src/qdrant_loader_mcp_server/search/components/vector_search_service.py
+++ b/packages/qdrant-loader-mcp-server/src/qdrant_loader_mcp_server/search/components/vector_search_service.py
@@ -251,15 +251,19 @@ class VectorSearchService:
                 parsed_query.field_queries, project_ids
             )
 
-            results = await self.qdrant_client.search(
+            # Use query_points() API (qdrant-client >= 1.10)
+            # Replaces deprecated search() method
+            query_response = await self.qdrant_client.query_points(
                 collection_name=self.collection_name,
-                query_vector=query_embedding,
+                query=query_embedding,
                 limit=limit,
                 score_threshold=self.min_score,
                 search_params=search_params,
                 query_filter=query_filter,
                 with_payload=True,  # 🔧 CRITICAL: Explicitly request payload data
             )
+            # query_points returns QueryResponse with .points attribute
+            results = query_response.points
 
         extracted_results = []
         for hit in results:


### PR DESCRIPTION
## Summary
- Replace deprecated `search()` method with `query_points()` for qdrant-client >= 1.10 compatibility

## Test plan
- [x] MCP search API returns results without AttributeError
- [x] Tested with poc_test collection

Fixes #1