### PR TITLE
[main] fix: add log level support to LoggingConfig.reconfigure()

### DIFF
--- a/packages/qdrant-loader/src/qdrant_loader/cli/commands/config.py
+++ b/packages/qdrant-loader/src/qdrant_loader/cli/commands/config.py
@@ -42,7 +42,7 @@ def run_show_config(
         )
         if getattr(LoggingConfig, "reconfigure", None):  # Core supports reconfigure
             if getattr(LoggingConfig, "_initialized", False):  # type: ignore[attr-defined]
-                LoggingConfig.reconfigure(file=log_file)  # type: ignore[attr-defined]
+                LoggingConfig.reconfigure(file=log_file, level=log_level)  # type: ignore[attr-defined]
             else:
                 LoggingConfig.setup(level=log_level, format="console", file=log_file)
         else:

--- a/packages/qdrant-loader/src/qdrant_loader/cli/commands/config_cmd.py
+++ b/packages/qdrant-loader/src/qdrant_loader/cli/commands/config_cmd.py
@@ -22,7 +22,7 @@ def run_config_command(
         )
         if getattr(LoggingConfig, "reconfigure", None):  # type: ignore[attr-defined]
             if getattr(LoggingConfig, "_initialized", False):  # type: ignore[attr-defined]
-                LoggingConfig.reconfigure(file=log_file)  # type: ignore[attr-defined]
+                LoggingConfig.reconfigure(file=log_file, level=log_level)  # type: ignore[attr-defined]
             else:
                 LoggingConfig.setup(level=log_level, format="console", file=log_file)
         else:

--- a/packages/qdrant-loader/src/qdrant_loader/cli/commands/ingest_cmd.py
+++ b/packages/qdrant-loader/src/qdrant_loader/cli/commands/ingest_cmd.py
@@ -51,7 +51,7 @@ async def run_ingest_command(
         )
         if getattr(LoggingConfig, "reconfigure", None):  # type: ignore[attr-defined]
             if getattr(LoggingConfig, "_initialized", False):  # type: ignore[attr-defined]
-                LoggingConfig.reconfigure(file=log_file)  # type: ignore[attr-defined]
+                LoggingConfig.reconfigure(file=log_file, level=log_level)  # type: ignore[attr-defined]
             else:
                 LoggingConfig.setup(level=log_level, format="console", file=log_file)
         else:

--- a/packages/qdrant-loader/src/qdrant_loader/cli/commands/init_cmd.py
+++ b/packages/qdrant-loader/src/qdrant_loader/cli/commands/init_cmd.py
@@ -42,7 +42,7 @@ async def run_init_command(
             # Setup logging first (workspace-aware later). Use core reconfigure if available.
             if getattr(LoggingConfig, "reconfigure", None):  # type: ignore[attr-defined]
                 if getattr(LoggingConfig, "_initialized", False):  # type: ignore[attr-defined]
-                    LoggingConfig.reconfigure(file="qdrant-loader.log")  # type: ignore[attr-defined]
+                    LoggingConfig.reconfigure(file="qdrant-loader.log", level=log_level)  # type: ignore[attr-defined]
                 else:
                     LoggingConfig.setup(
                         level=log_level, format="console", file="qdrant-loader.log"
@@ -88,7 +88,7 @@ async def run_init_command(
                 else "qdrant-loader.log"
             )
             if getattr(LoggingConfig, "reconfigure", None):  # type: ignore[attr-defined]
-                LoggingConfig.reconfigure(file=log_file)  # type: ignore[attr-defined]
+                LoggingConfig.reconfigure(file=log_file, level=log_level)  # type: ignore[attr-defined]
             else:
                 import logging as _py_logging
 


### PR DESCRIPTION
## Summary
- Allow --log-level flag to work after initial logging setup
- Add level parameter to reconfigure() method

## Test plan
- [x] DEBUG logs shown when using --log-level DEBUG

Fixes #4