### PR TITLE
[main] fix: update deprecated langchain import

### DIFF
--- a/packages/qdrant-loader/src/qdrant_loader/core/text_processing/text_processor.py
+++ b/packages/qdrant-loader/src/qdrant_loader/core/text_processing/text_processor.py
@@ -2,7 +2,7 @@
 
 import nltk
 import spacy
-from langchain.text_splitter import RecursiveCharacterTextSplitter
+from langchain_text_splitters import RecursiveCharacterTextSplitter
 from qdrant_loader.config import Settings
 from qdrant_loader.utils.logging import LoggingConfig
 from spacy.cli.download import download


### PR DESCRIPTION
## Summary
- Replace deprecated `langchain.text_splitter` with `langchain_text_splitters`

## Test plan
- [x] No deprecation warnings

Fixes #5