### PR TITLE
feat(chunking): implement hierarchy tracking from Unstructured.io pat…

### DIFF
--- a/packages/qdrant-loader/src/qdrant_loader/connectors/shared/__init__.py
+++ b/packages/qdrant-loader/src/qdrant_loader/connectors/shared/__init__.py
@@ -1,1 +1,19 @@
-"""Shared utilities for connectors (HTTP, attachments, etc.)."""
+"""Shared utilities for connectors (HTTP, attachments, hierarchy, etc.)."""
+
+from .hierarchy import (
+    HierarchyMetadata,
+    build_hierarchy_from_ancestors,
+    build_hierarchy_from_jira,
+    build_hierarchy_from_markdown_sections,
+    build_hierarchy_from_path,
+    merge_hierarchy_metadata,
+)
+
+__all__ = [
+    "HierarchyMetadata",
+    "build_hierarchy_from_path",
+    "build_hierarchy_from_ancestors",
+    "build_hierarchy_from_jira",
+    "build_hierarchy_from_markdown_sections",
+    "merge_hierarchy_metadata",
+]

--- a/packages/qdrant-loader/src/qdrant_loader/connectors/shared/hierarchy.py
+++ b/packages/qdrant-loader/src/qdrant_loader/connectors/shared/hierarchy.py
@@ -1,0 +1,320 @@
+"""Hierarchy tracking utilities for document metadata enrichment.
+
+POC1-002: Implements hierarchy tracking patterns inspired by Unstructured.io.
+Provides unified hierarchy metadata generation across all connector types.
+
+Key concepts:
+- parent_id: ID of the parent element (section, document, or container)
+- depth: Integer depth in hierarchy (0=root, 1=H1, 2=H2, etc.)
+- breadcrumb: List of ancestor titles ["Root", "Parent", "Current"]
+- breadcrumb_text: String representation "Root > Parent > Current"
+"""
+
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass
+class HierarchyMetadata:
+    """Standardized hierarchy metadata structure.
+
+    Attributes:
+        parent_id: ID of parent element (None for root)
+        depth: Depth in hierarchy (0 = root level)
+        breadcrumb: List of ancestor names
+        breadcrumb_text: Human-readable path string
+    """
+    parent_id: str | None
+    depth: int
+    breadcrumb: list[str]
+    breadcrumb_text: str
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to dictionary for metadata storage."""
+        return {
+            "parent_id": self.parent_id,
+            "depth": self.depth,
+            "breadcrumb": self.breadcrumb,
+            "breadcrumb_text": self.breadcrumb_text,
+        }
+
+
+def build_hierarchy_from_path(
+    file_path: str,
+    separator: str = "/",
+    root_name: str | None = None,
+) -> HierarchyMetadata:
+    """Build hierarchy metadata from a file path.
+
+    Used by: Git connector, LocalFile connector, PublicDocs connector.
+
+    Args:
+        file_path: File path like "docs/api/reference.md"
+        separator: Path separator (default "/")
+        root_name: Optional root name to prepend (e.g., repository name)
+
+    Returns:
+        HierarchyMetadata with path-based hierarchy
+
+    Example:
+        >>> build_hierarchy_from_path("docs/api/reference.md", root_name="my-repo")
+        HierarchyMetadata(
+            parent_id="docs/api",
+            depth=3,
+            breadcrumb=["my-repo", "docs", "api", "reference.md"],
+            breadcrumb_text="my-repo > docs > api > reference.md"
+        )
+    """
+    # Split path and filter empty segments
+    parts = [p for p in file_path.split(separator) if p]
+
+    # Prepend root name if provided
+    if root_name:
+        parts = [root_name] + parts
+
+    # Calculate depth (number of path segments)
+    depth = len(parts)
+
+    # Build breadcrumb
+    breadcrumb = parts.copy()
+
+    # Generate breadcrumb text
+    breadcrumb_text = " > ".join(breadcrumb)
+
+    # Parent ID is the directory path (excluding filename)
+    if len(parts) > 1:
+        parent_id = separator.join(parts[:-1])
+    else:
+        parent_id = None
+
+    return HierarchyMetadata(
+        parent_id=parent_id,
+        depth=depth,
+        breadcrumb=breadcrumb,
+        breadcrumb_text=breadcrumb_text,
+    )
+
+
+def build_hierarchy_from_ancestors(
+    ancestors: list[dict[str, Any]],
+    space_name: str | None = None,
+    current_title: str | None = None,
+) -> HierarchyMetadata:
+    """Build hierarchy metadata from Confluence-style ancestors.
+
+    Used by: Confluence connector.
+
+    Args:
+        ancestors: List of ancestor pages [{"id": "123", "title": "Parent"}, ...]
+        space_name: Optional space name to prepend
+        current_title: Current page title to append
+
+    Returns:
+        HierarchyMetadata with ancestor-based hierarchy
+
+    Example:
+        >>> ancestors = [
+        ...     {"id": "1", "title": "Documentation"},
+        ...     {"id": "2", "title": "API Reference"}
+        ... ]
+        >>> build_hierarchy_from_ancestors(ancestors, "DEV", "Auth API")
+        HierarchyMetadata(
+            parent_id="2",
+            depth=4,
+            breadcrumb=["DEV", "Documentation", "API Reference", "Auth API"],
+            breadcrumb_text="DEV > Documentation > API Reference > Auth API"
+        )
+    """
+    breadcrumb: list[str] = []
+
+    # Add space name as root
+    if space_name:
+        breadcrumb.append(space_name)
+
+    # Add ancestors in order (from root to immediate parent)
+    for ancestor in ancestors:
+        title = ancestor.get("title", ancestor.get("name", ""))
+        if title:
+            breadcrumb.append(title)
+
+    # Add current page title
+    if current_title:
+        breadcrumb.append(current_title)
+
+    # Depth is total breadcrumb length
+    depth = len(breadcrumb)
+
+    # Parent ID is the last ancestor's ID
+    parent_id = None
+    if ancestors:
+        parent_id = str(ancestors[-1].get("id", ""))
+
+    # Generate breadcrumb text
+    breadcrumb_text = " > ".join(breadcrumb)
+
+    return HierarchyMetadata(
+        parent_id=parent_id,
+        depth=depth,
+        breadcrumb=breadcrumb,
+        breadcrumb_text=breadcrumb_text,
+    )
+
+
+def build_hierarchy_from_jira(
+    issue_type: str,
+    parent_key: str | None = None,
+    epic_key: str | None = None,
+    project_key: str | None = None,
+    issue_key: str | None = None,
+) -> HierarchyMetadata:
+    """Build hierarchy metadata from JIRA issue relationships.
+
+    Used by: JIRA connector.
+
+    JIRA hierarchy: Project -> Epic -> Story/Task -> Sub-task
+
+    Args:
+        issue_type: Type of issue (Epic, Story, Task, Sub-task, Bug)
+        parent_key: Parent issue key (for sub-tasks)
+        epic_key: Epic key (for stories/tasks linked to epic)
+        project_key: Project key
+        issue_key: Current issue key
+
+    Returns:
+        HierarchyMetadata with JIRA-based hierarchy
+
+    Example:
+        >>> build_hierarchy_from_jira(
+        ...     issue_type="Sub-task",
+        ...     parent_key="PROJ-100",
+        ...     epic_key="PROJ-50",
+        ...     project_key="PROJ",
+        ...     issue_key="PROJ-101"
+        ... )
+        HierarchyMetadata(
+            parent_id="PROJ-100",
+            depth=4,
+            breadcrumb=["PROJ", "PROJ-50", "PROJ-100", "PROJ-101"],
+            breadcrumb_text="PROJ > PROJ-50 > PROJ-100 > PROJ-101"
+        )
+    """
+    breadcrumb: list[str] = []
+
+    # Always start with project
+    if project_key:
+        breadcrumb.append(project_key)
+
+    # Add epic if present (for non-epic issues)
+    if epic_key and issue_type.lower() != "epic":
+        breadcrumb.append(epic_key)
+
+    # Add parent for sub-tasks
+    if parent_key and issue_type.lower() == "sub-task":
+        breadcrumb.append(parent_key)
+
+    # Add current issue
+    if issue_key:
+        breadcrumb.append(issue_key)
+
+    # Calculate depth based on issue type
+    depth = len(breadcrumb)
+
+    # Determine parent ID based on hierarchy
+    parent_id = None
+    if issue_type.lower() == "sub-task" and parent_key:
+        parent_id = parent_key
+    elif epic_key and issue_type.lower() != "epic":
+        parent_id = epic_key
+    elif project_key and issue_type.lower() == "epic":
+        parent_id = project_key
+
+    # Generate breadcrumb text
+    breadcrumb_text = " > ".join(breadcrumb)
+
+    return HierarchyMetadata(
+        parent_id=parent_id,
+        depth=depth,
+        breadcrumb=breadcrumb,
+        breadcrumb_text=breadcrumb_text,
+    )
+
+
+def build_hierarchy_from_markdown_sections(
+    section_path: list[str],
+    section_level: int,
+    document_id: str | None = None,
+    document_title: str | None = None,
+    section_id: str | None = None,
+    parent_section_id: str | None = None,
+) -> HierarchyMetadata:
+    """Build hierarchy metadata from markdown section structure.
+
+    Used by: Markdown chunking strategy.
+
+    Args:
+        section_path: List of parent section titles ["H1 Title", "H2 Title"]
+        section_level: Current section header level (1-6)
+        document_id: Source document ID
+        document_title: Source document title
+        section_id: Current section/chunk ID
+        parent_section_id: Parent section/chunk ID
+
+    Returns:
+        HierarchyMetadata with section-based hierarchy
+
+    Example:
+        >>> build_hierarchy_from_markdown_sections(
+        ...     section_path=["Installation", "Prerequisites"],
+        ...     section_level=3,
+        ...     document_title="Getting Started Guide"
+        ... )
+        HierarchyMetadata(
+            parent_id=None,
+            depth=3,
+            breadcrumb=["Getting Started Guide", "Installation", "Prerequisites"],
+            breadcrumb_text="Getting Started Guide > Installation > Prerequisites"
+        )
+    """
+    breadcrumb: list[str] = []
+
+    # Add document title as root if provided
+    if document_title:
+        breadcrumb.append(document_title)
+
+    # Add section path
+    breadcrumb.extend(section_path)
+
+    # Depth is based on section level (H1=1, H2=2, etc.)
+    # Add 1 for document level
+    depth = section_level + (1 if document_title else 0)
+
+    # Use parent_section_id if provided, otherwise construct from path
+    parent_id = parent_section_id
+
+    # Generate breadcrumb text
+    breadcrumb_text = " > ".join(breadcrumb)
+
+    return HierarchyMetadata(
+        parent_id=parent_id,
+        depth=depth,
+        breadcrumb=breadcrumb,
+        breadcrumb_text=breadcrumb_text,
+    )
+
+
+def merge_hierarchy_metadata(
+    base_metadata: dict[str, Any],
+    hierarchy: HierarchyMetadata,
+) -> dict[str, Any]:
+    """Merge hierarchy metadata into existing document metadata.
+
+    Args:
+        base_metadata: Existing document metadata dictionary
+        hierarchy: HierarchyMetadata to merge
+
+    Returns:
+        Updated metadata dictionary with hierarchy fields
+    """
+    result = base_metadata.copy()
+    result.update(hierarchy.to_dict())
+    return result

--- a/packages/qdrant-loader/src/qdrant_loader/core/chunking/strategy/base_strategy.py
+++ b/packages/qdrant-loader/src/qdrant_loader/core/chunking/strategy/base_strategy.py
@@ -338,8 +338,11 @@ class BaseChunkingStrategy(ABC):
         chunk_index: int,
         total_chunks: int,
         skip_nlp: bool = False,
+        split_method: str | None = None,
     ) -> Document:
         """Create a new document for a chunk with enhanced metadata.
+
+        POC1-009: Added split provenance metadata for full traceability.
 
         Args:
             original_doc: Original document
@@ -347,16 +350,26 @@ class BaseChunkingStrategy(ABC):
             chunk_index: Index of the chunk
             total_chunks: Total number of chunks
             skip_nlp: Whether to skip expensive NLP processing
+            split_method: The chunking strategy used (e.g., "markdown", "code", "default")
 
         Returns:
             Document: New document instance for the chunk
         """
         # Create enhanced metadata
         metadata = original_doc.metadata.copy()
+
+        # POC1-009: Split provenance metadata (Haystack pattern)
+        # Enables "show me all chunks from document X" queries
+        # and full traceability from chunk back to source
         metadata.update(
             {
                 "chunk_index": chunk_index,
                 "total_chunks": total_chunks,
+                # Split provenance fields
+                "parent_document_id": original_doc.id,
+                "parent_document_title": original_doc.title,
+                "split_index": chunk_index,
+                "split_method": split_method or self.__class__.__name__,
             }
         )
 

--- a/packages/qdrant-loader/src/qdrant_loader/core/chunking/strategy/markdown/markdown_strategy.py
+++ b/packages/qdrant-loader/src/qdrant_loader/core/chunking/strategy/markdown/markdown_strategy.py
@@ -102,6 +102,12 @@ class MarkdownChunkingStrategy(BaseChunkingStrategy):
                 self.progress_tracker.finish_chunking(document.id, 0, "markdown")
                 return []
 
+            # POC1-008: Enrich chunks with standardized hierarchy metadata
+            logger.debug("Enriching chunks with hierarchy metadata")
+            chunks_metadata = self.section_splitter.enrich_chunks_with_hierarchy(
+                document, chunks_metadata
+            )
+
             # Apply configuration-driven safety limit
             max_chunks = self.settings.global_config.chunking.max_chunks_per_document
             if len(chunks_metadata) > max_chunks:

--- a/packages/qdrant-loader/src/qdrant_loader/core/qdrant_manager.py
+++ b/packages/qdrant-loader/src/qdrant_loader/core/qdrant_manager.py
@@ -169,6 +169,10 @@ class QdrantManager:
                 ),  # Hierarchical relationships
                 ("original_file_type", {"type": "keyword"}),  # File type filtering
                 ("is_converted", {"type": "bool"}),  # Conversion status filtering
+                # Hierarchy tracking indexes (POC1-001: from Unstructured pattern)
+                ("parent_id", {"type": "keyword"}),  # Parent chunk/section ID
+                ("depth", {"type": "integer"}),  # Hierarchy depth (0=root, 1=H1, 2=H2...)
+                ("breadcrumb_text", {"type": "text"}),  # "Root > Section > Subsection"
             ]
 
             # Create indexes with proper error handling

--- a/packages/qdrant-loader/tests/unit/connectors/shared/test_hierarchy.py
+++ b/packages/qdrant-loader/tests/unit/connectors/shared/test_hierarchy.py
@@ -1,0 +1,440 @@
+"""Unit tests for hierarchy tracking utilities.
+
+POC1-010: Tests for the hierarchy module implementing the Unstructured.io pattern.
+"""
+
+from qdrant_loader.connectors.shared.hierarchy import (
+    HierarchyMetadata,
+    build_hierarchy_from_ancestors,
+    build_hierarchy_from_jira,
+    build_hierarchy_from_markdown_sections,
+    build_hierarchy_from_path,
+    merge_hierarchy_metadata,
+)
+
+
+class TestHierarchyMetadata:
+    """Tests for HierarchyMetadata dataclass."""
+
+    def test_to_dict(self):
+        """Test conversion to dictionary."""
+        hierarchy = HierarchyMetadata(
+            parent_id="parent-123",
+            depth=2,
+            breadcrumb=["Root", "Parent", "Current"],
+            breadcrumb_text="Root > Parent > Current",
+        )
+
+        result = hierarchy.to_dict()
+
+        assert result == {
+            "parent_id": "parent-123",
+            "depth": 2,
+            "breadcrumb": ["Root", "Parent", "Current"],
+            "breadcrumb_text": "Root > Parent > Current",
+        }
+
+    def test_to_dict_with_none_parent(self):
+        """Test conversion when parent_id is None (root element)."""
+        hierarchy = HierarchyMetadata(
+            parent_id=None,
+            depth=0,
+            breadcrumb=["Root"],
+            breadcrumb_text="Root",
+        )
+
+        result = hierarchy.to_dict()
+
+        assert result["parent_id"] is None
+        assert result["depth"] == 0
+
+
+class TestBuildHierarchyFromPath:
+    """Tests for build_hierarchy_from_path function (Git, LocalFile, PublicDocs)."""
+
+    def test_simple_path(self):
+        """Test with a simple file path."""
+        result = build_hierarchy_from_path("docs/api/reference.md")
+
+        assert result.depth == 3
+        assert result.breadcrumb == ["docs", "api", "reference.md"]
+        assert result.breadcrumb_text == "docs > api > reference.md"
+        assert result.parent_id == "docs/api"
+
+    def test_path_with_root_name(self):
+        """Test with a root name (repository name)."""
+        result = build_hierarchy_from_path(
+            "docs/api/reference.md", root_name="my-repo"
+        )
+
+        assert result.depth == 4
+        assert result.breadcrumb == ["my-repo", "docs", "api", "reference.md"]
+        assert result.breadcrumb_text == "my-repo > docs > api > reference.md"
+        assert result.parent_id == "my-repo/docs/api"
+
+    def test_single_file(self):
+        """Test with a single file (no directories)."""
+        result = build_hierarchy_from_path("README.md")
+
+        assert result.depth == 1
+        assert result.breadcrumb == ["README.md"]
+        assert result.breadcrumb_text == "README.md"
+        assert result.parent_id is None
+
+    def test_single_file_with_root(self):
+        """Test single file with root name."""
+        result = build_hierarchy_from_path("README.md", root_name="project")
+
+        assert result.depth == 2
+        assert result.breadcrumb == ["project", "README.md"]
+        assert result.parent_id == "project"
+
+    def test_deep_path(self):
+        """Test with a deeply nested path."""
+        result = build_hierarchy_from_path(
+            "src/core/chunking/strategy/markdown/splitters/base.py"
+        )
+
+        assert result.depth == 7
+        assert len(result.breadcrumb) == 7
+        assert result.breadcrumb[-1] == "base.py"
+        assert result.parent_id == "src/core/chunking/strategy/markdown/splitters"
+
+    def test_windows_path(self):
+        """Test with backslash separator (Windows paths)."""
+        result = build_hierarchy_from_path(
+            "docs\\api\\reference.md", separator="\\"
+        )
+
+        assert result.depth == 3
+        assert result.breadcrumb == ["docs", "api", "reference.md"]
+
+    def test_empty_segments_filtered(self):
+        """Test that empty path segments are filtered out."""
+        result = build_hierarchy_from_path("docs//api///reference.md")
+
+        assert result.depth == 3
+        assert "" not in result.breadcrumb
+
+
+class TestBuildHierarchyFromAncestors:
+    """Tests for build_hierarchy_from_ancestors function (Confluence)."""
+
+    def test_with_ancestors_and_space(self):
+        """Test with Confluence ancestors and space name."""
+        ancestors = [
+            {"id": "1", "title": "Documentation"},
+            {"id": "2", "title": "API Reference"},
+        ]
+
+        result = build_hierarchy_from_ancestors(
+            ancestors, space_name="DEV", current_title="Auth API"
+        )
+
+        assert result.depth == 4
+        assert result.breadcrumb == ["DEV", "Documentation", "API Reference", "Auth API"]
+        assert result.breadcrumb_text == "DEV > Documentation > API Reference > Auth API"
+        assert result.parent_id == "2"
+
+    def test_without_space_name(self):
+        """Test without space name."""
+        ancestors = [{"id": "1", "title": "Parent"}]
+
+        result = build_hierarchy_from_ancestors(
+            ancestors, current_title="Current Page"
+        )
+
+        assert result.depth == 2
+        assert result.breadcrumb == ["Parent", "Current Page"]
+        assert result.parent_id == "1"
+
+    def test_empty_ancestors(self):
+        """Test with no ancestors (root page)."""
+        result = build_hierarchy_from_ancestors(
+            [], space_name="TEAM", current_title="Home"
+        )
+
+        assert result.depth == 2
+        assert result.breadcrumb == ["TEAM", "Home"]
+        assert result.parent_id is None
+
+    def test_ancestors_with_name_key(self):
+        """Test ancestors using 'name' instead of 'title'."""
+        ancestors = [{"id": "1", "name": "Parent Section"}]
+
+        result = build_hierarchy_from_ancestors(ancestors, current_title="Child")
+
+        assert result.breadcrumb == ["Parent Section", "Child"]
+
+    def test_only_space_name(self):
+        """Test with only space name (root of space)."""
+        result = build_hierarchy_from_ancestors([], space_name="DOCS")
+
+        assert result.depth == 1
+        assert result.breadcrumb == ["DOCS"]
+
+
+class TestBuildHierarchyFromJira:
+    """Tests for build_hierarchy_from_jira function."""
+
+    def test_epic_hierarchy(self):
+        """Test Epic (top-level under project)."""
+        result = build_hierarchy_from_jira(
+            issue_type="Epic",
+            project_key="PROJ",
+            issue_key="PROJ-50",
+        )
+
+        assert result.depth == 2
+        assert result.breadcrumb == ["PROJ", "PROJ-50"]
+        assert result.parent_id == "PROJ"
+
+    def test_story_with_epic(self):
+        """Test Story linked to Epic."""
+        result = build_hierarchy_from_jira(
+            issue_type="Story",
+            epic_key="PROJ-50",
+            project_key="PROJ",
+            issue_key="PROJ-100",
+        )
+
+        assert result.depth == 3
+        assert result.breadcrumb == ["PROJ", "PROJ-50", "PROJ-100"]
+        assert result.parent_id == "PROJ-50"
+
+    def test_subtask(self):
+        """Test Sub-task with parent and epic."""
+        result = build_hierarchy_from_jira(
+            issue_type="Sub-task",
+            parent_key="PROJ-100",
+            epic_key="PROJ-50",
+            project_key="PROJ",
+            issue_key="PROJ-101",
+        )
+
+        assert result.depth == 4
+        assert result.breadcrumb == ["PROJ", "PROJ-50", "PROJ-100", "PROJ-101"]
+        assert result.parent_id == "PROJ-100"
+
+    def test_task_without_epic(self):
+        """Test Task without Epic."""
+        result = build_hierarchy_from_jira(
+            issue_type="Task",
+            project_key="PROJ",
+            issue_key="PROJ-200",
+        )
+
+        assert result.depth == 2
+        assert result.breadcrumb == ["PROJ", "PROJ-200"]
+        # No epic, so parent is None (task is under project but not hierarchically)
+        assert result.parent_id is None
+
+    def test_bug_with_epic(self):
+        """Test Bug linked to Epic."""
+        result = build_hierarchy_from_jira(
+            issue_type="Bug",
+            epic_key="PROJ-10",
+            project_key="PROJ",
+            issue_key="PROJ-300",
+        )
+
+        assert result.depth == 3
+        assert result.parent_id == "PROJ-10"
+
+
+class TestBuildHierarchyFromMarkdownSections:
+    """Tests for build_hierarchy_from_markdown_sections function."""
+
+    def test_basic_section(self):
+        """Test basic section hierarchy."""
+        result = build_hierarchy_from_markdown_sections(
+            section_path=["Installation"],
+            section_level=1,
+            document_title="Getting Started",
+        )
+
+        assert result.depth == 2  # 1 for doc title + 1 for section level
+        assert result.breadcrumb == ["Getting Started", "Installation"]
+        assert result.breadcrumb_text == "Getting Started > Installation"
+
+    def test_nested_section(self):
+        """Test nested section with path."""
+        result = build_hierarchy_from_markdown_sections(
+            section_path=["Installation", "Prerequisites"],
+            section_level=2,
+            document_title="Guide",
+        )
+
+        assert result.depth == 3
+        assert result.breadcrumb == ["Guide", "Installation", "Prerequisites"]
+
+    def test_without_document_title(self):
+        """Test section without document title."""
+        result = build_hierarchy_from_markdown_sections(
+            section_path=["Overview"],
+            section_level=1,
+        )
+
+        assert result.depth == 1
+        assert result.breadcrumb == ["Overview"]
+        assert result.breadcrumb_text == "Overview"
+
+    def test_with_parent_section_id(self):
+        """Test with explicit parent section ID."""
+        result = build_hierarchy_from_markdown_sections(
+            section_path=["API", "Methods"],
+            section_level=2,
+            document_id="doc-123",
+            document_title="Reference",
+            parent_section_id="doc-123_chunk_0",
+        )
+
+        assert result.parent_id == "doc-123_chunk_0"
+        assert result.depth == 3
+
+    def test_empty_path(self):
+        """Test with empty section path (preamble/content before headers)."""
+        result = build_hierarchy_from_markdown_sections(
+            section_path=[],
+            section_level=0,
+            document_title="README",
+        )
+
+        assert result.depth == 1
+        assert result.breadcrumb == ["README"]
+
+
+class TestMergeHierarchyMetadata:
+    """Tests for merge_hierarchy_metadata function."""
+
+    def test_merge_into_empty_metadata(self):
+        """Test merging into empty metadata."""
+        base = {}
+        hierarchy = HierarchyMetadata(
+            parent_id="parent-1",
+            depth=2,
+            breadcrumb=["A", "B"],
+            breadcrumb_text="A > B",
+        )
+
+        result = merge_hierarchy_metadata(base, hierarchy)
+
+        assert result["parent_id"] == "parent-1"
+        assert result["depth"] == 2
+        assert result["breadcrumb"] == ["A", "B"]
+        assert result["breadcrumb_text"] == "A > B"
+
+    def test_merge_preserves_existing(self):
+        """Test that merge preserves existing metadata."""
+        base = {
+            "title": "My Document",
+            "source": "git",
+            "custom_field": "value",
+        }
+        hierarchy = HierarchyMetadata(
+            parent_id="parent-1",
+            depth=1,
+            breadcrumb=["Doc"],
+            breadcrumb_text="Doc",
+        )
+
+        result = merge_hierarchy_metadata(base, hierarchy)
+
+        assert result["title"] == "My Document"
+        assert result["source"] == "git"
+        assert result["custom_field"] == "value"
+        assert result["parent_id"] == "parent-1"
+
+    def test_merge_does_not_modify_original(self):
+        """Test that original metadata is not modified."""
+        base = {"existing": "value"}
+        hierarchy = HierarchyMetadata(
+            parent_id="p1",
+            depth=1,
+            breadcrumb=["X"],
+            breadcrumb_text="X",
+        )
+
+        result = merge_hierarchy_metadata(base, hierarchy)
+
+        assert "parent_id" not in base
+        assert result is not base
+
+
+class TestIntegrationScenarios:
+    """Integration tests for real-world scenarios."""
+
+    def test_git_repository_file(self):
+        """Test hierarchy for a file in a Git repository."""
+        hierarchy = build_hierarchy_from_path(
+            "packages/qdrant-loader/src/qdrant_loader/core/document.py",
+            root_name="qdrant-loader",
+        )
+
+        assert hierarchy.depth == 7
+        assert hierarchy.breadcrumb[0] == "qdrant-loader"
+        assert hierarchy.breadcrumb[-1] == "document.py"
+        assert "core" in hierarchy.breadcrumb
+
+    def test_confluence_page_hierarchy(self):
+        """Test hierarchy for a Confluence page."""
+        ancestors = [
+            {"id": "100", "title": "Engineering"},
+            {"id": "200", "title": "Backend"},
+            {"id": "300", "title": "API Documentation"},
+        ]
+
+        hierarchy = build_hierarchy_from_ancestors(
+            ancestors,
+            space_name="TECH",
+            current_title="Authentication Guide",
+        )
+
+        assert hierarchy.depth == 5
+        assert hierarchy.breadcrumb_text == (
+            "TECH > Engineering > Backend > API Documentation > Authentication Guide"
+        )
+        assert hierarchy.parent_id == "300"
+
+    def test_jira_subtask_hierarchy(self):
+        """Test hierarchy for a JIRA sub-task."""
+        hierarchy = build_hierarchy_from_jira(
+            issue_type="Sub-task",
+            parent_key="PROJ-100",
+            epic_key="PROJ-50",
+            project_key="PROJ",
+            issue_key="PROJ-101",
+        )
+
+        # Full path: PROJ -> PROJ-50 (epic) -> PROJ-100 (parent) -> PROJ-101
+        assert hierarchy.depth == 4
+        assert hierarchy.breadcrumb == ["PROJ", "PROJ-50", "PROJ-100", "PROJ-101"]
+
+    def test_markdown_document_sections(self):
+        """Test hierarchy for markdown document sections."""
+        # Simulate chunking a document with multiple levels
+        chunks = [
+            {"path": [], "level": 1, "title": "Introduction"},
+            {"path": ["Introduction"], "level": 2, "title": "Overview"},
+            {"path": ["Introduction"], "level": 2, "title": "Goals"},
+            {"path": [], "level": 1, "title": "Implementation"},
+            {"path": ["Implementation"], "level": 2, "title": "Architecture"},
+            {"path": ["Implementation", "Architecture"], "level": 3, "title": "Components"},
+        ]
+
+        hierarchies = []
+        for chunk in chunks:
+            h = build_hierarchy_from_markdown_sections(
+                section_path=chunk["path"] + [chunk["title"]],
+                section_level=chunk["level"],
+                document_title="Design Doc",
+            )
+            hierarchies.append(h)
+
+        # Verify structure
+        assert hierarchies[0].breadcrumb_text == "Design Doc > Introduction"
+        assert hierarchies[1].breadcrumb_text == "Design Doc > Introduction > Overview"
+        assert hierarchies[5].breadcrumb_text == (
+            "Design Doc > Implementation > Architecture > Components"
+        )
+        assert hierarchies[5].depth == 4


### PR DESCRIPTION
# Pull Request

  ## Summary

  Implement hierarchy tracking inspired by Unstructured.io pattern for document metadata enrichment. Adds unified `HierarchyMetadata` structure with builder functions for all connector types, payload
  indexes for optimized filtering, and stack-based parent tracking for markdown sections.

  **Key components:**
  - **POC1-001**: Qdrant payload indexes for `parent_id`, `depth`, `breadcrumb_text` fields
  - **POC1-002**: `HierarchyMetadata` dataclass with builders for path-based, ancestor-based, JIRA, and markdown section hierarchies
  - **POC1-008**: Stack-based `_build_hierarchy_map()` algorithm for markdown section splitting
  - **POC1-009**: Split provenance metadata (`parent_document_id`, `split_index`, `split_method`)

  ## Type of change

  - [x] Feature
  - [ ] Bug fix
  - [ ] Docs update
  - [ ] Chore

  ## Docs Impact (required for any code or docs changes)

  - [x] Does this change require docs updates? If yes, list pages:
    - RELEASE_NOTES.md (updated)
    - Inline docstrings for all new classes and functions
  - [x] Have you updated or added pages under `docs/`?
  - [ ] Did you build the site and run the link checker? (`python website/build.py` + `python website/check_links.py`)
  - [x] Did you avoid banned placeholders? (no "TBD/coming soon")

  ## Testing

  ```bash
  # Run POC1 hierarchy tests (31 tests)
  pytest packages/qdrant-loader/tests/unit/connectors/shared/test_hierarchy.py -v

  # Results:
  # - test_hierarchy.py: 31 passed

  Checklist

  - Tests pass (pytest -v)
  - Linting passes (make lint / make format)
  - Documentation updated (if applicable)

  ---
  Related: POC1 Hierarchy Tracking from Unstructured.io
  Branch: poc/hierarchy-tracking-from-unstructured

  ---

  **Files Changed (7 files):**
  | File | Description |
  |------|-------------|
  | `connectors/shared/__init__.py` | Export hierarchy module |
  | `connectors/shared/hierarchy.py` | **NEW** - HierarchyMetadata + builder functions |
  | `core/qdrant_manager.py` | Payload indexes for hierarchy fields |
  | `core/chunking/strategy/base_strategy.py` | Split provenance metadata |
  | `core/chunking/strategy/markdown/markdown_strategy.py` | Hierarchy integration |
  | `core/chunking/strategy/markdown/section_splitter.py` | Stack-based parent tracking |
  | `tests/unit/connectors/shared/test_hierarchy.py` | **NEW** - 31 unit tests |